### PR TITLE
BACK-1160 README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ Please have a look on `docker-compose.yml` file for more details on the configur
 
 ##### Build and publish image in local
 
-`sbt bitcoinWorker/assembly && sbt bitcoinWorker/docker`
+Import dependencies of the project :
+
+    git submodule init
+    git submodule upgrate --remote --recursive
+
+And then run `sbt bitcoinWorker/assembly && sbt bitcoinWorker/docker`
 
 #### Run manually
 
@@ -72,7 +77,12 @@ Please have a look on `docker-compose.yml` file for more details on the configur
 
 ##### Build and publish image in local
 
-`sbt bitcoinInterpreter/assembly && sbt bitcoinInterpreter/docker`
+Import dependencies of the project :
+
+    git submodule init
+    git submodule upgrate --remote --recursive
+
+Then run `sbt bitcoinInterpreter/assembly && sbt bitcoinInterpreter/docker`
 
 #### Run manually
 
@@ -88,7 +98,12 @@ Please have a look on `docker-compose.yml` file for more details on the configur
 
 ##### Build and publish image in local
 
-`sbt bitcoinApi/assembly && sbt bitcoinApi/docker`
+Import dependencies of the project :
+
+    git submodule init
+    git submodule upgrate --remote --recursive
+
+Then run `sbt bitcoinApi/assembly && sbt bitcoinApi/docker`
 
 #### Run manually
 


### PR DESCRIPTION
## What is this about?

Some bitoin modules rely on external repositories. The doc reminds to import submodules.

## Cute picture of lama
![lama](https://user-images.githubusercontent.com/11653587/90911060-b5c13280-e3d8-11ea-9e92-d55e347836e2.jpg)
