### PR TITLE
BACK-1233 mark new change address as used

### DIFF
--- a/coins/bitcoin/transactor/src/main/scala/co/ledger/lama/bitcoin/transactor/Transactor.scala
+++ b/coins/bitcoin/transactor/src/main/scala/co/ledger/lama/bitcoin/transactor/Transactor.scala
@@ -85,6 +85,8 @@ class Transactor(
         outputs.map(_.value).sum
       )
 
+      _ <- keychainClient.markAddressesAsUsed(keychainId, List(changeAddress.accountAddress))
+
     } yield rawTransaction
 
   }


### PR DESCRIPTION
## What is this about?

Mark new change address as used upon transaction creation

## Cute picture of lama
![images](https://user-images.githubusercontent.com/1628443/107249670-dbe49880-6a33-11eb-87ec-46bc3bbdbc93.jpeg)

