### PR TITLE
BACK 1607 - Save mempool in transaction table

### DIFF
--- a/.env
+++ b/.env
@@ -57,7 +57,9 @@ BITCOIN_TRANSACTOR_SSL=false
 # Bitcoin worker
 # On huge account (many txs by addresses), do not limit heap
 BITCOIN_WORKER_JAVA_OPTS=-Xmx50m -Xms30m
-BITCOIN_EXPLORER_URI=https://explorers.api.live.ledger.com
+BITCOIN_EXPLORER_URI=https://explorers.api-01.vault.ledger-stg.com
+# use prod explorer for big account synchronization
+#BITCOIN_EXPLORER_URI=https://explorers.api.live.ledger.com
 BITCOIN_EXPLORER_ADDRESSES_SIZE=20
 BITCOIN_EXPLORER_TXS_BATCH_SIZE=1000
 BITCOIN_EXPLORER_TIMEOUT=60 seconds

--- a/coins/bitcoin/api/src/test/scala/co/ledger/lama/bitcoin/api/routes/AccountControllerSpec.scala
+++ b/coins/bitcoin/api/src/test/scala/co/ledger/lama/bitcoin/api/routes/AccountControllerSpec.scala
@@ -55,8 +55,7 @@ class AccountControllerSpec extends AnyFlatSpec with Matchers {
           scriptHex = "",
           changeType = None,
           derivation = NonEmptyList.one(1),
-          time = Instant.now,
-          usedInMempool = false
+          time = Instant.now
         )
       )
     ),

--- a/coins/bitcoin/common/src/main/scala/co/ledger/lama/bitcoin/common/clients/grpc/InterpreterClient.scala
+++ b/coins/bitcoin/common/src/main/scala/co/ledger/lama/bitcoin/common/clients/grpc/InterpreterClient.scala
@@ -14,8 +14,6 @@ import io.grpc.{ManagedChannel, Metadata}
 trait InterpreterClient {
   def saveTransactions(accountId: UUID, txs: List[TransactionView]): IO[Int]
 
-  def saveUnconfirmedTransactions(accountId: UUID, txs: List[TransactionView]): IO[Int]
-
   def removeDataFromCursor(accountId: UUID, blockHeightCursor: Option[Long]): IO[Int]
 
   def getLastBlocks(accountId: UUID): IO[List[BlockView]]
@@ -77,17 +75,6 @@ class InterpreterGrpcClient(
   def saveTransactions(accountId: UUID, txs: List[TransactionView]): IO[Int] =
     client
       .saveTransactions(
-        protobuf.SaveTransactionsRequest(
-          accountId = UuidUtils uuidToBytes accountId,
-          transactions = txs.map(_.toProto)
-        ),
-        new Metadata()
-      )
-      .map(_.count)
-
-  def saveUnconfirmedTransactions(accountId: UUID, txs: List[TransactionView]): IO[Int] =
-    client
-      .saveUnconfirmedTransactions(
         protobuf.SaveTransactionsRequest(
           accountId = UuidUtils uuidToBytes accountId,
           transactions = txs.map(_.toProto)

--- a/coins/bitcoin/common/src/main/scala/co/ledger/lama/bitcoin/common/models/interpreter/Utxo.scala
+++ b/coins/bitcoin/common/src/main/scala/co/ledger/lama/bitcoin/common/models/interpreter/Utxo.scala
@@ -17,8 +17,7 @@ case class Utxo(
     scriptHex: String,
     changeType: Option[ChangeType],
     derivation: NonEmptyList[Int],
-    time: Instant,
-    usedInMempool: Boolean = false
+    time: Instant
 ) {
   def toProto: protobuf.Utxo =
     protobuf.Utxo(
@@ -29,8 +28,7 @@ case class Utxo(
       scriptHex,
       changeType.getOrElse(ChangeType.External).toProto,
       derivation.toList,
-      Some(TimestampProtoUtils.serialize(time)),
-      usedInMempool
+      Some(TimestampProtoUtils.serialize(time))
     )
 }
 
@@ -47,7 +45,6 @@ object Utxo {
       proto.scriptHex,
       Some(ChangeType.fromProto(proto.changeType)),
       NonEmptyList.fromListUnsafe(proto.derivation.toList),
-      proto.time.map(TimestampProtoUtils.deserialize).getOrElse(Instant.now()),
-      proto.usedInMempool
+      proto.time.map(TimestampProtoUtils.deserialize).getOrElse(Instant.now())
     )
 }

--- a/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/BalanceIT.scala
+++ b/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/BalanceIT.scala
@@ -309,13 +309,13 @@ class BalanceIT extends AnyFlatSpecLike with Matchers with TestResources {
 
         } yield {
           current.balance shouldBe BigInt(24434)
-          current.unconfirmedBalance shouldBe BigInt(16000)
+          current.unconfirmedBalance shouldBe BigInt(-8434)
           current.utxos shouldBe 2
           current.received shouldBe BigInt(105000)
           current.sent shouldBe BigInt(80566)
 
           balances should have size 4
-          balances.last.balance shouldBe current.unconfirmedBalance
+          balances.last.balance shouldBe current.unconfirmedBalance + current.balance
         }
       }
   }

--- a/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/BalanceIT.scala
+++ b/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/BalanceIT.scala
@@ -292,7 +292,7 @@ class BalanceIT extends AnyFlatSpecLike with Matchers with TestResources {
           _ <- QueryUtils.saveTx(db, tx1, accountId)
           _ <- QueryUtils.saveTx(db, tx2, accountId)
           _ <- QueryUtils.saveTx(db, tx3, accountId)
-          _ <- QueryUtils.saveUnconfirmedTxView(db, accountId, List(unconfirmedTx))
+          _ <- QueryUtils.saveTx(db, unconfirmedTx, accountId)
           _ <- flaggingService.flagInputsAndOutputs(
             accountId,
             List(address2, address3, address1)

--- a/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/InterpreterIT.scala
+++ b/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/InterpreterIT.scala
@@ -95,8 +95,7 @@ class InterpreterIT extends AnyFlatSpecLike with Matchers with TestResources {
           _ <- interpreter.compute(
             accountId,
             List(inputAddress, outputAddress2),
-            Coin.Btc,
-            block.height
+            Coin.Btc
           )
 
           resOpsBeforeDeletion <- interpreter.getOperations(
@@ -196,13 +195,12 @@ class InterpreterIT extends AnyFlatSpecLike with Matchers with TestResources {
         )
 
         for {
-          _ <- interpreter.saveUnconfirmedTransactions(accountId, List(uTx))
-          _ <- interpreter.saveUnconfirmedTransactions(accountId, List(uTx2))
+          _ <- interpreter.saveTransactions(accountId, List(uTx))
+          _ <- interpreter.saveTransactions(accountId, List(uTx2))
           _ <- interpreter.compute(
             accountId,
             List(outputAddress1),
-            Coin.Btc,
-            block.height
+            Coin.Btc
           )
           res <- interpreter.getOperations(accountId, 0L, 20, 0, Sort.Descending)
           GetOperationsResult(operations, _, _) = res
@@ -221,7 +219,7 @@ class InterpreterIT extends AnyFlatSpecLike with Matchers with TestResources {
 
   }
 
-  "an unconfirmed transaction" should "not be saved if it's been mined" in IOAssertion {
+  "an unconfirmed transaction" should "be updated if it's been mined" in IOAssertion {
     setup() *>
       appResources.use { db =>
         val interpreter = new Interpreter(_ => IO.unit, db, 1)
@@ -251,13 +249,12 @@ class InterpreterIT extends AnyFlatSpecLike with Matchers with TestResources {
         )
 
         for {
-          _ <- interpreter.saveUnconfirmedTransactions(accountId, List(uTx))
+          _ <- interpreter.saveTransactions(accountId, List(uTx))
           _ <- interpreter.saveTransactions(accountId, List(tx))
           _ <- interpreter.compute(
             accountId,
             List(outputAddress1),
-            Coin.Btc,
-            block.height
+            Coin.Btc
           )
           res <- interpreter.getOperations(accountId, 0L, 20, 0, Sort.Descending)
           GetOperationsResult(operations, _, _) = res

--- a/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/OperationServiceIT.scala
+++ b/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/OperationServiceIT.scala
@@ -333,11 +333,8 @@ class OperationServiceIT extends AnyFlatSpecLike with Matchers with TestResource
         )
 
         for {
-          _ <- QueryUtils.saveUnconfirmedTxView(
-            db,
-            accountId,
-            List(unconfirmedTransaction1, unconfirmedTransaction2)
-          )
+          _     <- QueryUtils.saveTx(db, unconfirmedTransaction1, accountId)
+          _     <- QueryUtils.saveTx(db, unconfirmedTransaction2, accountId)
           utxos <- operationService.getUnconfirmedUtxos(accountId)
         } yield {
           utxos should have size 2

--- a/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/QueryUtils.scala
+++ b/coins/bitcoin/interpreter/src/it/scala/co.ledger.lama.bitcoin.interpreter/QueryUtils.scala
@@ -25,28 +25,6 @@ object QueryUtils {
       .void
   }
 
-  def saveUnconfirmedTxs(
-      db: Transactor[IO],
-      accountId: UUID,
-      transactions: List[TransactionView]
-  ): IO[Unit] = {
-    TransactionQueries
-      .saveUnconfirmedTransactions(accountId, transactions)
-      .transact(db)
-      .void
-  }
-
-  def saveUnconfirmedTxView(
-      db: Transactor[IO],
-      accountId: UUID,
-      transactions: List[TransactionView]
-  ): IO[Unit] = {
-    OperationQueries
-      .saveUnconfirmedTransactionView(accountId, transactions)
-      .transact(db)
-      .void
-  }
-
   def fetchOps(db: Transactor[IO], accountId: UUID): IO[List[Operation]] = {
     OperationQueries
       .fetchOperations(accountId)

--- a/coins/bitcoin/interpreter/src/main/resources/db/migration/V9__optional_transaction_block.sql
+++ b/coins/bitcoin/interpreter/src/main/resources/db/migration/V9__optional_transaction_block.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "transaction" ALTER COLUMN block_hash DROP NOT NULL;
+ALTER TABLE "transaction" ALTER COLUMN block_height DROP NOT NULL;
+ALTER TABLE "transaction" ALTER COLUMN block_time DROP NOT NULL;
+
+ALTER TABLE operation ADD
+    FOREIGN KEY (account_id, hash) REFERENCES transaction (account_id, hash) ON DELETE CASCADE;
+
+DROP TABLE unconfirmed_transaction_view;
+DROP TABLE unconfirmed_transaction_cache;

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/Interpreter.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/Interpreter.scala
@@ -78,15 +78,14 @@ class Interpreter(
       blockHeight: Long
   ): IO[Int] = {
     for {
-      txRes <- transactionService.removeFromCursor(accountId, blockHeight)
-      _     <- operationService.removeFromCursor(accountId, blockHeight)
-      _     <- log.info(s"Deleted $txRes transactions")
+      opRes <- operationService.removeFromCursor(accountId, blockHeight)
+      _     <- log.info(s"Deleted $opRes operations")
       balancesRes <- balanceService.removeBalanceHistoryFromCursor(
         accountId,
         blockHeight
       )
       _ <- log.info(s"Deleted $balancesRes balances history")
-    } yield txRes
+    } yield opRes
   }
 
   def compute(

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/Interpreter.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/Interpreter.scala
@@ -78,14 +78,14 @@ class Interpreter(
       blockHeight: Long
   ): IO[Int] = {
     for {
-      opRes <- operationService.removeFromCursor(accountId, blockHeight)
-      _     <- log.info(s"Deleted $opRes operations")
+      txRes <- transactionService.removeFromCursor(accountId, blockHeight)
+      _     <- log.info(s"Deleted $txRes operations")
       balancesRes <- balanceService.removeBalanceHistoryFromCursor(
         accountId,
         blockHeight
       )
       _ <- log.info(s"Deleted $balancesRes balances history")
-    } yield opRes
+    } yield txRes
   }
 
   def compute(

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/Interpreter.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/Interpreter.scala
@@ -31,12 +31,6 @@ class Interpreter(
   ): IO[Int] =
     transactionService.saveTransactions(accountId, transactions)
 
-  def saveUnconfirmedTransactions(
-      accountId: UUID,
-      transactions: List[TransactionView]
-  ): IO[Int] =
-    transactionService.saveUnconfirmedTransactions(accountId, transactions)
-
   def getLastBlocks(
       accountId: UUID
   ): IO[List[BlockView]] =
@@ -85,9 +79,7 @@ class Interpreter(
   ): IO[Int] = {
     for {
       txRes <- transactionService.removeFromCursor(accountId, blockHeight)
-      _     <- transactionService.deleteUnconfirmedTransaction(accountId)
       _     <- operationService.removeFromCursor(accountId, blockHeight)
-      _     <- operationService.deleteUnconfirmedTransactionView(accountId)
       _     <- log.info(s"Deleted $txRes transactions")
       balancesRes <- balanceService.removeBalanceHistoryFromCursor(
         accountId,
@@ -100,8 +92,7 @@ class Interpreter(
   def compute(
       accountId: UUID,
       addresses: List[AccountAddress],
-      coin: Coin,
-      lastBlockHeight: Long
+      coin: Coin
   ): IO[Int] =
     for {
       balanceHistoryCount <- balanceService.getBalanceHistoryCount(accountId)
@@ -109,19 +100,6 @@ class Interpreter(
       nbSavedOps <- saveOperationsAndNotify(
         accountId,
         operationService.compute(accountId),
-        addresses,
-        coin,
-        balanceHistoryCount > 0
-      )
-
-      unconfirmedTransactions <- computeAndSaveUnconfirmedTxs(accountId, addresses, lastBlockHeight)
-      unconfirmedOperations = unconfirmedTransactions.flatMap(
-        OperationToSave.fromTransactionView(accountId, _)
-      )
-
-      _ <- saveOperationsAndNotify(
-        accountId,
-        Stream.emits(unconfirmedOperations),
         addresses,
         coin,
         balanceHistoryCount > 0
@@ -141,49 +119,6 @@ class Interpreter(
       )
 
     } yield nbSavedOps
-
-  def computeAndSaveUnconfirmedTxs(
-      accountId: UUID,
-      addresses: List[AccountAddress],
-      lastBlockHeight: Long
-  ): IO[List[TransactionView]] =
-    for {
-      unconfirmedTransactions <- transactionService.fetchUnconfirmedTransactions(accountId)
-
-      // This is temporary... Will disappear in the next PR
-      unconfirmedTransactionsViews = unconfirmedTransactions.map { tx =>
-        tx.copy(
-          outputs = tx.outputs.map { o =>
-            val addressO = addresses.find(_.accountAddress == o.address)
-            o.copy(
-              changeType = addressO.map(_.changeType),
-              derivation = addressO.map(_.derivation)
-            )
-          },
-          inputs = tx.inputs.map { i =>
-            i.copy(
-              derivation = addresses.find(_.accountAddress == i.address).map(_.derivation)
-            )
-          }
-        )
-      }
-
-      //remove tx mined in between
-      minedTxs <- operationService.getOperations(
-        accountId,
-        lastBlockHeight,
-        1000,
-        0,
-        Sort.Descending
-      )
-      dedupTxs = unconfirmedTransactionsViews.filterNot(utx =>
-        minedTxs.operations.exists(tx => tx.hash == utx.hash)
-      )
-
-      _ <- operationService.deleteUnconfirmedTransactionView(accountId)
-      _ <- operationService.saveUnconfirmedTransactionView(accountId, dedupTxs)
-      _ <- transactionService.deleteUnconfirmedTransaction(accountId)
-    } yield dedupTxs
 
   def saveOperationsAndNotify(
       accountId: UUID,

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/InterpreterService.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/InterpreterService.scala
@@ -29,18 +29,6 @@ class InterpreterGrpcService(
     } yield protobuf.ResultCount(savedCount)
   }
 
-  def saveUnconfirmedTransactions(
-      request: protobuf.SaveTransactionsRequest,
-      ctx: Metadata
-  ): IO[protobuf.ResultCount] = {
-    for {
-      accountId  <- UuidUtils.bytesToUuidIO(request.accountId)
-      _          <- log.info(s"Saving ${request.transactions.size} transactions for $accountId")
-      txs        <- IO(request.transactions.map(TransactionView.fromProto).toList)
-      savedCount <- interpreter.saveTransactions(accountId, txs)
-    } yield protobuf.ResultCount(savedCount)
-  }
-
   def getLastBlocks(
       request: protobuf.GetLastBlocksRequest,
       ctx: Metadata

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/InterpreterService.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/InterpreterService.scala
@@ -37,7 +37,7 @@ class InterpreterGrpcService(
       accountId  <- UuidUtils.bytesToUuidIO(request.accountId)
       _          <- log.info(s"Saving ${request.transactions.size} transactions for $accountId")
       txs        <- IO(request.transactions.map(TransactionView.fromProto).toList)
-      savedCount <- interpreter.saveUnconfirmedTransactions(accountId, txs)
+      savedCount <- interpreter.saveTransactions(accountId, txs)
     } yield protobuf.ResultCount(savedCount)
   }
 
@@ -140,7 +140,7 @@ class InterpreterGrpcService(
       )
       accountId <- UuidUtils.bytesToUuidIO(request.accountId)
       addresses <- IO(request.addresses.map(AccountAddress.fromProto).toList)
-      nbOps     <- interpreter.compute(accountId, addresses, coin, request.lastBlockHeight)
+      nbOps     <- interpreter.compute(accountId, addresses, coin)
     } yield protobuf.ResultCount(nbOps)
 
   def getBalance(

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/services/BalanceService.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/services/BalanceService.scala
@@ -41,18 +41,19 @@ class BalanceService(db: Transactor[IO]) extends IOLogging {
     } yield nbSaved
 
   def getCurrentBalance(accountId: UUID): IO[CurrentBalance] =
-    for {
-      blockchainBalance <- BalanceQueries.getBlockchainBalance(accountId).transact(db)
-      mempoolBalance    <- BalanceQueries.getUnconfirmedBalance(accountId).transact(db)
-    } yield {
-      CurrentBalance(
-        blockchainBalance.balance,
-        blockchainBalance.utxos,
-        blockchainBalance.received,
-        blockchainBalance.sent,
-        mempoolBalance
+    BalanceQueries
+      .getBlockchainBalance(accountId)
+      .flatMap(mempoolBalance => BalanceQueries.getUnconfirmedBalance(accountId))
+      .map(blockchainBalance =>
+        CurrentBalance(
+          blockchainBalance.balance,
+          blockchainBalance.utxos,
+          blockchainBalance.received,
+          blockchainBalance.sent,
+          mempoolBalance
+        )
       )
-    }
+      .transact(db)
 
   def getBalanceHistory(
       accountId: UUID,

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/services/BalanceService.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/services/BalanceService.scala
@@ -42,15 +42,15 @@ class BalanceService(db: Transactor[IO]) extends IOLogging {
 
   def getCurrentBalance(accountId: UUID): IO[CurrentBalance] =
     for {
-      blockchainBalance    <- BalanceQueries.getBlockchainBalance(accountId).transact(db)
-      mempoolBalanceAmount <- getMempoolBalanceAmount(accountId)
+      blockchainBalance <- BalanceQueries.getBlockchainBalance(accountId).transact(db)
+      mempoolBalance    <- BalanceQueries.getUnconfirmedBalance(accountId).transact(db)
     } yield {
       CurrentBalance(
         blockchainBalance.balance,
         blockchainBalance.utxos,
         blockchainBalance.received,
         blockchainBalance.sent,
-        blockchainBalance.balance + mempoolBalanceAmount
+        mempoolBalance
       )
     }
 
@@ -76,14 +76,15 @@ class BalanceService(db: Transactor[IO]) extends IOLogging {
 
       mempoolIsInTimeRange = endO.forall(end => end.isAfter(Instant.now()))
 
+      // Either last balance, or previous balance if no balance in time range or nobalance
+      lastBalance = balances.lastOption.orElse(previousBalance).map(_.balance).getOrElse(BigInt(0))
+
       // Add mempool balance to the last balance
       withMempoolBalance <-
         if (mempoolIsInTimeRange) {
-          // Either last balance, or previous balance if no balance in time range or nobalance
-          val lastBalance =
-            balances.lastOption.orElse(previousBalance).map(_.balance).getOrElse(BigInt(0))
-
-          getMempoolBalanceAmount(accountId)
+          BalanceQueries
+            .getUnconfirmedBalance(accountId)
+            .transact(db)
             .map(amount =>
               balances.appended(
                 BalanceHistory(
@@ -202,23 +203,6 @@ class BalanceService(db: Transactor[IO]) extends IOLogging {
       interval
     ).reverse
 
-  }
-
-  def getMempoolBalanceAmount(
-      accountId: UUID
-  ): IO[BigInt] = {
-    OperationQueries
-      .fetchUnconfirmedTransactionsViews(accountId)
-      .transact(db)
-      .map {
-        case Nil => BigInt(0)
-        case txs =>
-          txs.foldLeft(BigInt(0)) { (balance, tx) =>
-            balance +
-              tx.outputs.collect { case o if o.belongs => o.value }.sum -
-              tx.inputs.collect { case i if i.belongs => i.value }.sum
-          }
-      }
   }
 
 }

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/services/OperationQueries.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/services/OperationQueries.scala
@@ -139,29 +139,6 @@ object OperationQueries extends IOLogging {
     Update[OperationToSave](query).updateMany(operation)
   }
 
-  def fetchUnconfirmedTransactions(
-      accountId: UUID
-  ): ConnectionIO[List[TransactionView]] = {
-    log.logger.debug(s"Fetching transactions for accountId $accountId")
-    sql"""SELECT transaction_views
-          FROM unconfirmed_transaction_view
-          WHERE account_id = $accountId
-       """
-      .query[Json]
-      .option
-      .map { t =>
-        t.map(_.as[List[TransactionView]]) match {
-          case Some(result) =>
-            result.leftMap { error =>
-              log.error("Could not parse TansactionView list json : ", error)
-              error
-            }
-          case None => Right(List.empty[TransactionView])
-        }
-      }
-      .rethrow
-  }
-
   def deleteUnconfirmedOperations(accountId: UUID): doobie.ConnectionIO[Int] = {
     sql"""DELETE FROM operation
          WHERE account_id = $accountId

--- a/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/services/OperationQueries.scala
+++ b/coins/bitcoin/interpreter/src/main/scala/co/ledger/lama/bitcoin/interpreter/services/OperationQueries.scala
@@ -3,9 +3,7 @@ package co.ledger.lama.bitcoin.interpreter.services
 import java.util.UUID
 
 import cats.data.NonEmptyList
-import cats.implicits._
 import co.ledger.lama.bitcoin.common.models.interpreter._
-import co.ledger.lama.common.models.implicits._
 import co.ledger.lama.bitcoin.interpreter.models.{OperationToSave, TransactionAmounts}
 import co.ledger.lama.bitcoin.interpreter.models.implicits._
 import co.ledger.lama.common.logging.IOLogging
@@ -14,7 +12,6 @@ import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import fs2.{Chunk, Stream}
-import io.circe.Json
 
 object OperationQueries extends IOLogging {
 

--- a/coins/bitcoin/protobuf/src/main/protobuf/interpreter.proto
+++ b/coins/bitcoin/protobuf/src/main/protobuf/interpreter.proto
@@ -11,7 +11,6 @@ option java_package = "co.ledger.lama.bitcoin.interpreter.protobuf";
 
 service BitcoinInterpreterService {
   rpc SaveTransactions(SaveTransactionsRequest) returns (ResultCount) {}
-  rpc SaveUnconfirmedTransactions(SaveTransactionsRequest) returns (ResultCount) {}
   rpc GetLastBlocks(GetLastBlocksRequest) returns (GetLastBlocksResult) {}
   rpc RemoveDataFromCursor(DeleteTransactionsRequest) returns (ResultCount) {}
   rpc GetOperations(GetOperationsRequest) returns (GetOperationsResult) {}

--- a/coins/bitcoin/protobuf/src/main/protobuf/operation.proto
+++ b/coins/bitcoin/protobuf/src/main/protobuf/operation.proto
@@ -70,7 +70,6 @@ message Utxo {
   ChangeType change_type = 6;
   repeated uint32 derivation = 7;
   google.protobuf.Timestamp time = 8;
-  bool used_in_mempool = 9;
 }
 
 message BlockView {

--- a/coins/bitcoin/transactor/src/main/scala/co/ledger/lama/bitcoin/transactor/Transactor.scala
+++ b/coins/bitcoin/transactor/src/main/scala/co/ledger/lama/bitcoin/transactor/Transactor.scala
@@ -43,7 +43,7 @@ class Transactor(
 
       accountInfo <- keychainClient.getKeychainInfo(keychainId)
 
-      utxos <- getUTXOs(accountId, 100, Sort.Ascending).filter(!_.usedInMempool).compile.toList
+      utxos <- getUTXOs(accountId, 100, Sort.Ascending).compile.toList
       _ <- log.info(
         s"""Utxos found for account $accountId:
             - number of utxos: ${utxos.size}

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/services/Bookkeeper.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/services/Bookkeeper.scala
@@ -147,7 +147,7 @@ object Bookkeeper {
     def save(interpreter: InterpreterClient)(accountId: AccountId, txs: List[Tx]): IO[String] =
       for {
         savedTxsCount <- interpreter.saveTransactions(accountId, txs.map(_.toTransactionView))
-      } yield s"$savedTxsCount new transactions saved from blockchain"
+      } yield s"$savedTxsCount new transactions saved"
   }
 
   implicit def confirmed(implicit

--- a/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/services/Bookkeeper.scala
+++ b/coins/bitcoin/worker/src/main/scala/co/ledger/lama/bitcoin/worker/services/Bookkeeper.scala
@@ -144,7 +144,10 @@ object Bookkeeper {
         explorer: ExplorerClient
     )(addresses: Set[Address], block: Option[BlockHash]): Stream[IO, Tx]
 
-    def save(interpreter: InterpreterClient)(accountId: AccountId, txs: List[Tx]): IO[String]
+    def save(interpreter: InterpreterClient)(accountId: AccountId, txs: List[Tx]): IO[String] =
+      for {
+        savedTxsCount <- interpreter.saveTransactions(accountId, txs.map(_.toTransactionView))
+      } yield s"$savedTxsCount new transactions saved from blockchain"
   }
 
   implicit def confirmed(implicit
@@ -156,13 +159,6 @@ object Bookkeeper {
           explorer: ExplorerClient
       )(addresses: Set[Address], block: Option[BlockHash]): Stream[IO, ConfirmedTransaction] =
         explorer.getConfirmedTransactions(addresses.toSeq, block)
-
-      override def save(
-          interpreter: InterpreterClient
-      )(accountId: AccountId, txs: List[ConfirmedTransaction]): IO[String] =
-        for {
-          savedTxsCount <- interpreter.saveTransactions(accountId, txs.map(_.toTransactionView))
-        } yield s"$savedTxsCount new transactions saved from blockchain"
     }
 
   implicit def unconfirmedTransaction(implicit
@@ -174,17 +170,6 @@ object Bookkeeper {
           explorer: ExplorerClient
       )(addresses: Set[Address], block: Option[BlockHash]): Stream[IO, UnconfirmedTransaction] =
         explorer.getUnconfirmedTransactions(addresses)
-
-      override def save(
-          interpreter: InterpreterClient
-      )(accountId: AccountId, txs: List[UnconfirmedTransaction]): IO[String] =
-        for {
-          savedTxsCount <- interpreter.saveUnconfirmedTransactions(
-            accountId,
-            txs.map(_.toTransactionView)
-          )
-        } yield s"$savedTxsCount new transactions saved from mempool"
-
     }
 
   case class BatchResult(


### PR DESCRIPTION
## What is this about?

Use Transaction table to store unconfirmed transactions (without block)

## Cute picture of lama
![eatingllama](https://user-images.githubusercontent.com/1628443/110505330-54f01200-80fe-11eb-9939-6af54c73f006.jpeg)
